### PR TITLE
Report default CallExpression exports

### DIFF
--- a/src/only-export-components.ts
+++ b/src/only-export-components.ts
@@ -97,6 +97,8 @@ export const onlyExportComponents: TSESLint.RuleModule<
             } else {
               handleExportIdentifier(node.id);
             }
+          } else if (node.type === "CallExpression") {
+            context.report({ messageId: "anonymousExport", node });
           }
         };
 
@@ -108,7 +110,8 @@ export const onlyExportComponents: TSESLint.RuleModule<
             hasExports = true;
             if (
               node.declaration.type === "VariableDeclaration" ||
-              node.declaration.type === "FunctionDeclaration"
+              node.declaration.type === "FunctionDeclaration" ||
+              node.declaration.type === "CallExpression"
             ) {
               handleExportDeclaration(node.declaration);
             }

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -78,6 +78,22 @@ const valid = [
     filename: "Test.js",
     options: [{ checkJS: true }],
   },
+  {
+    name: "HOC",
+    code: `
+      const MainPageHeader = () => <HeaderWrapper/>
+      export const SubScreen =  withRouter(MainPageHeader);
+    `,
+    filename: "Test.jsx",
+    },
+    {
+      name: "export default HOC",
+      code: `
+        const MainPageHeader = () => <HeaderWrapper/>
+        export default withRouter(MainPageHeader);
+      `,
+      filename: "Test.jsx",
+      },
 ];
 
 const invalid = [
@@ -135,7 +151,7 @@ const invalid = [
     filename: "Test.js",
     options: [{ checkJS: true }],
     errorId: "namedExport",
-  },
+  }
 ];
 
 let failedTests = 0;

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -78,22 +78,6 @@ const valid = [
     filename: "Test.js",
     options: [{ checkJS: true }],
   },
-  {
-    name: "HOC",
-    code: `
-      const MainPageHeader = () => <HeaderWrapper/>
-      export const SubScreen =  withRouter(MainPageHeader);
-    `,
-    filename: "Test.jsx",
-    },
-    {
-      name: "export default HOC",
-      code: `
-        const MainPageHeader = () => <HeaderWrapper/>
-        export default withRouter(MainPageHeader);
-      `,
-      filename: "Test.jsx",
-      },
 ];
 
 const invalid = [
@@ -151,7 +135,13 @@ const invalid = [
     filename: "Test.js",
     options: [{ checkJS: true }],
     errorId: "namedExport",
-  }
+  },
+  {
+    name: "export default compose",
+    code: `export default compose()(MainView);`,
+    filename: "Test.jsx",
+    errorId: "anonymousExport",
+  },
 ];
 
 let failedTests = 0;


### PR DESCRIPTION
This pattern is from redux's compose util primarily.

Fix #6 