### PR TITLE
Remove plugin from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ npm i -D eslint-plugin-react-refresh
 
 ```json
 {
-  "plugins": ["react-refresh"],
   "rules": {
     "react-refresh/only-export-components": "warn"
   }


### PR DESCRIPTION
This is not necessary and produces an error: `ESLint couldn't find the config "react-refresh" to extend from. Please check that the name of the config is correct.`