### PR TITLE
Add recommended config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,14 @@
 import { onlyExportComponents } from "./only-export-components.ts";
 
+export const configs = {
+  recommended: {
+    plugins: ["react-refresh"],
+    rules: {
+      "react-refresh/only-export-components": "warn",
+    },
+  },
+};
+
 export const rules = {
   "only-export-components": onlyExportComponents,
 };


### PR DESCRIPTION
Hi, this lint plugin is the only one that i use custom rules for and i was wondering why there is no recommended config for it?

@adamschachne Would you consider adding `{ "allowConstantExport": true }` to the recommended config too?