### PR TITLE
Add `createContextMethods` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,3 +140,22 @@ If your using JSX inside `.js` files (which I don't recommend because it forces 
   "react-refresh/only-export-components": ["warn", { "checkJS": true }]
 }
 ```
+
+### createContextMethods
+
+The `createContextMethods` option allows you to specify custom context-creating functions for detection by the rule. By default, it only detects `createContext`, but you can add methods like `createMyContext` in your configuration.
+
+```json
+{
+  "react-refresh/only-export-components": [
+    "error",
+    { "createContextMethods": ["createMyContext"] }
+  ]
+}
+```
+
+```jsx
+export const MyComponent = () => <div />;
+// ESLint error
+export const MyContext = createMyContext();
+```

--- a/src/only-export-components.test.ts
+++ b/src/only-export-components.test.ts
@@ -189,6 +189,21 @@ const valid = [
     name: "Only React context",
     code: "export const MyContext = createContext('test');",
   },
+  {
+    name: "Component and local React Context from other module",
+    code: "export const MyComponent = () => {}; const MyContext = createMyContext('test');",
+    errorId: "reactContext",
+    options: [
+      {
+        createContextMethods: ["createMyContext"],
+      },
+    ],
+  },
+  {
+    name: "Component and React Context from other module without options",
+    code: "export const MyComponent = () => {}; export const MyContext = createMyContext('test');",
+    errorId: "reactContext",
+  },
 ];
 
 const invalid = [
@@ -294,6 +309,16 @@ const invalid = [
     name: "Component and React Context with React import",
     code: "export const MyComponent = () => {}; export const MyContext = React.createContext('test');",
     errorId: "reactContext",
+  },
+  {
+    name: "Component and React Context from other module",
+    code: "export const MyComponent = () => {}; export const MyContext = createMyContext('test');",
+    errorId: "reactContext",
+    options: [
+      {
+        createContextMethods: ["createMyContext"],
+      },
+    ],
   },
 ];
 

--- a/src/only-export-components.test.ts
+++ b/src/only-export-components.test.ts
@@ -315,9 +315,7 @@ const invalid = [
     code: "export const MyComponent = () => {}; export const MyContext = createMyContext('test');",
     errorId: "reactContext",
     options: [
-      {
-        createContextMethods: ["createMyContext"],
-      },
+      { createContextMethods: ["createMyContext"] },
     ],
   },
 ];

--- a/src/only-export-components.test.ts
+++ b/src/only-export-components.test.ts
@@ -190,19 +190,8 @@ const valid = [
     code: "export const MyContext = createContext('test');",
   },
   {
-    name: "Component and local React Context from other module",
-    code: "export const MyComponent = () => {}; const MyContext = createMyContext('test');",
-    errorId: "reactContext",
-    options: [
-      {
-        createContextMethods: ["createMyContext"],
-      },
-    ],
-  },
-  {
     name: "Component and React Context from other module without options",
     code: "export const MyComponent = () => {}; export const MyContext = createMyContext('test');",
-    errorId: "reactContext",
   },
 ];
 

--- a/src/only-export-components.ts
+++ b/src/only-export-components.ts
@@ -82,10 +82,10 @@ export const onlyExportComponents: TSESLint.RuleModule<
       ? new Set(allowExportNames)
       : undefined;
 
-    const createContextMethodsSet = new Set([
+    const createContextMethods = [
       ...createContextMethods,
       "createContext",
-    ]);
+    ];
 
     return {
       Program(program) {

--- a/src/only-export-components.ts
+++ b/src/only-export-components.ts
@@ -21,6 +21,7 @@ export const onlyExportComponents: TSESLint.RuleModule<
         allowConstantExport?: boolean;
         checkJS?: boolean;
         allowExportNames?: string[];
+        createContextMethods?: string[];
       },
     ]
 > = {
@@ -47,6 +48,7 @@ export const onlyExportComponents: TSESLint.RuleModule<
           allowConstantExport: { type: "boolean" },
           checkJS: { type: "boolean" },
           allowExportNames: { type: "array", items: { type: "string" } },
+          createContextMethods: { type: "array", items: { type: "string" } },
         },
         additionalProperties: false,
       },
@@ -58,6 +60,7 @@ export const onlyExportComponents: TSESLint.RuleModule<
       allowConstantExport = false,
       checkJS = false,
       allowExportNames,
+      createContextMethods = [],
     } = context.options[0] ?? {};
     const filename = context.filename;
     // Skip tests & stories files
@@ -78,6 +81,11 @@ export const onlyExportComponents: TSESLint.RuleModule<
     const allowExportNamesSet = allowExportNames
       ? new Set(allowExportNames)
       : undefined;
+
+    const createContextMethodsSet = new Set([
+      ...createContextMethods,
+      "createContext",
+    ]);
 
     return {
       Program(program) {
@@ -133,10 +141,10 @@ export const onlyExportComponents: TSESLint.RuleModule<
               init.type === "CallExpression" &&
               // createContext || React.createContext
               ((init.callee.type === "Identifier" &&
-                init.callee.name === "createContext") ||
+                createContextMethodsSet.has(init.callee.name)) ||
                 (init.callee.type === "MemberExpression" &&
                   init.callee.property.type === "Identifier" &&
-                  init.callee.property.name === "createContext"))
+                  createContextMethodsSet.has(init.callee.property.name)))
             ) {
               reactContextExports.push(identifierNode);
               return;


### PR DESCRIPTION
This allows users to specify custom context-creating methods, in addition to the default `createContext` from React.

```json
{
  "rules": {
    "react-refresh/only-export-components": ["error", {
      "createContextMethods": ["createMyContext"]
    }]
  }
}
```

```jsx
import { createMyContext } from './utils';

export const MyComponent = () => <div />;
// error
export const MyContext = createMyContext();
```

Related: #54 