### PR TITLE
Add basic support for custom HOCs

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,14 +141,14 @@ If your using JSX inside `.js` files (which I don't recommend because it forces 
 }
 ```
 
-### customHOCs
+### customHOCs <small>(v0.4.15)</small>
 
 If you're exporting a component wrapped in a custom HOC, you can use this option to avoid false positives.
 
 ```json
 {
   "react-refresh/only-export-components": [
-    "warn", 
+    "error",
     { "customHOCs": ["observer", "withAuth"] }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -140,3 +140,16 @@ If your using JSX inside `.js` files (which I don't recommend because it forces 
   "react-refresh/only-export-components": ["warn", { "checkJS": true }]
 }
 ```
+
+### customHOCs
+
+If you're exporting a component wrapped in a custom HOC, you can use this option to avoid false positives.
+
+```json
+{
+  "react-refresh/only-export-components": [
+    "warn", 
+    { "customHOCs": ["observer", "withAuth"] }
+  ]
+}
+```

--- a/src/only-export-components.test.ts
+++ b/src/only-export-components.test.ts
@@ -189,6 +189,11 @@ const valid = [
     name: "Only React context",
     code: "export const MyContext = createContext('test');",
   },
+  {
+    name: "Custom HOCs like mobx's observer",
+    code: "const MyComponent = () => {}; export default observer(MyComponent);",
+    options: [{ customHOCs: ["observer"] }],
+  },
 ];
 
 const invalid = [
@@ -295,6 +300,11 @@ const invalid = [
     code: "export const MyComponent = () => {}; export const MyContext = React.createContext('test');",
     errorId: "reactContext",
   },
+  {
+    name: "should be invalid when custom HOC is used without adding it to the rule configuration",
+    code: "const MyComponent = () => {}; export default observer(MyComponent);",
+    errorId: ["localComponents", "anonymousExport"],
+  },
 ];
 
 const it = (name: string, cases: Parameters<typeof ruleTester.run>[2]) => {
@@ -322,7 +332,9 @@ for (const { name, code, errorId, filename, options = [] } of invalid) {
       {
         filename: filename ?? "Test.jsx",
         code,
-        errors: [{ messageId: errorId }],
+        errors: Array.isArray(errorId)
+          ? errorId.map((messageId) => ({ messageId }))
+          : [{ messageId: errorId }],
         options,
       },
     ],


### PR DESCRIPTION
Fixes #59 for MobX's `observer` and other custom HOCs that follow the most common pattern.

**HOC pattern covered (simple HOCs):**

```js
export default observer(Component);
```

**HOC patterns not covered** because we would need to refactor to look for component identifiers in other argument positions (not just the first), and most likely generalize the implementation for redux's `connect` HOC.

```js
export default withMultipleParameters(
  () => {},
  () => {},
  Component
);
```

```js
export default reduxLikeConnect(
  () => {},
  () => {},
)(Component);
```

Adding support for simple HOCs brings the most value because HOCs with weird implementations, such as the one with multiple parameters and the component coming last, might be rare (we have some of those in my work codebase, but we'll replace these with hooks).

As follow-up work, it might be nice to detect exported components with HOCs that aren't in the `customHOCs` list and raise a particular error message that tells the developer about the `customHOCs` setting.

Thoughts? cc @ArnaudBarre 