### PR TITLE
docs: refresh README.md with explainer and options types

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ const defaultOptions: Options = {
   allowExportNames: [],
   allowConstantExport: false,
   checkJS: false,
-}
+};
 ```
 
 ### allowExportNames <small>(v0.4.4)</small>
@@ -129,7 +129,7 @@ const defaultOptions: Options = {
 
 If you use a framework that handles HMR of some specific exports, you can use this option to avoid warning for them.
 
-Example for [Remix](https://remix.run/docs/en/main/other-api/dev#:~:text=React%20Fast%20Refresh,-can%20only%20handle):
+Example for [Remix](https://remix.run/docs/en/main/discussion/hot-module-replacement#supported-exports):
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -2,11 +2,18 @@
 
 Validate that your components can safely be updated with fast refresh.
 
-## Limitations
+## Explainer
 
-⚠️ To avoid false positive, by default this plugin is only applied on `tsx` & `jsx` files. See options to run on JS files. ⚠️
+"Fast refresh", also known as "hot reloading", is a feature in many modern bundlers.
+If you update some React component(s) on disk, then the bundler will know to update only the impacted parts of your page -- without a full page reload.
 
-The plugin rely on naming conventions (i.e. use PascalCase for components, camelCase for util functions). This is why there are some limitations:
+`eslint-plugin-react-refresh` enforces that your components are structured in a way that integrations such as [react-refresh](https://www.npmjs.com/package/react-refresh) expect.
+
+### Limitations
+
+⚠️ To avoid false positives, by default this plugin is only applied on `tsx` & `jsx` files. See [Options](#options) to run on JS files. ⚠️
+
+The plugin relies on naming conventions (i.e. use PascalCase for components, camelCase for util functions). This is why there are some limitations:
 
 - `export *` are not supported and will be reported as an error
 - Anonymous function are not supported (i.e `export default function() {}`)
@@ -21,16 +28,7 @@ npm i -D eslint-plugin-react-refresh
 
 ## Usage
 
-```json
-{
-  "plugins": ["react-refresh"],
-  "rules": {
-    "react-refresh/only-export-components": "warn"
-  }
-}
-```
-
-### Flat config
+This plugin provides a single rule, `react-refresh/only-export-components`.
 
 ```js
 import reactRefresh from "eslint-plugin-react-refresh";
@@ -48,7 +46,22 @@ export default [
 ];
 ```
 
-## Fail
+### Legacy config
+
+```jsonc
+{
+  "plugins": ["react-refresh"],
+  "rules": {
+    "react-refresh/only-export-components": "warn"
+  }
+}
+```
+
+## Examples
+
+These examples are from enabling `react-refresh/only-exports-components`.
+
+### Fail
 
 ```jsx
 export const foo = () => {};
@@ -74,14 +87,7 @@ const App = () => {};
 createRoot(document.getElementById("root")).render(<App />);
 ```
 
-## Pass with allowConstantExport
-
-```jsx
-export const CONSTANT = 3;
-export const Foo = () => <></>;
-```
-
-## Pass
+### Pass
 
 ```jsx
 export default function Foo() {
@@ -101,7 +107,25 @@ createRoot(document.getElementById("root")).render(<App />);
 
 ## Options
 
+These options are all present on `react-refresh/only-exports-components`.
+
+```ts
+interface Options {
+  allowExportNames?: string[];
+  allowConstantExport?: boolean;
+  checkJS?: boolean;
+}
+
+const defaultOptions: Options = {
+  allowExportNames: [],
+  allowConstantExport: false,
+  checkJS: false,
+}
+```
+
 ### allowExportNames <small>(v0.4.4)</small>
+
+> Default: `[]`
 
 If you use a framework that handles HMR of some specific exports, you can use this option to avoid warning for them.
 
@@ -118,6 +142,8 @@ Example for [Remix](https://remix.run/docs/en/main/other-api/dev#:~:text=React%2
 
 ### allowConstantExport <small>(v0.4.0)</small>
 
+> Default: `false`
+
 Don't warn when a constant (string, number, boolean, templateLiteral) is exported aside one or more components.
 
 This should be enabled if the fast refresh implementation correctly handles this case (HMR when the constant doesn't change, propagate update to importers when the constant changes.). Vite supports it, PR welcome if you notice other integrations works well.
@@ -131,7 +157,16 @@ This should be enabled if the fast refresh implementation correctly handles this
 }
 ```
 
+Enabling this option allows code such as the following:
+
+```jsx
+export const CONSTANT = 3;
+export const Foo = () => <></>;
+```
+
 ### checkJS <small>(v0.3.3)</small>
+
+> Default: `false`
 
 If your using JSX inside `.js` files (which I don't recommend because it forces you to configure every tool you use to switch the parser), you can still use the plugin by enabling this option. To reduce the number of false positive, only files importing `react` are checked.
 


### PR DESCRIPTION
Fixes #28. Fixes #62.

"Refreshes" _(ha)_ the README.md:

* Adds a top-level explainer for what "fast refresh" / "hot reloading" are with a link to [react-refresh](https://www.npmjs.com/package/react-refresh)
* Explicitly calls out in a few places that there's just the one `only-export-components` rule
* Moved Flat config to the primary location and Legacy config to its own section
* Adds basic types & default options docs for options, similar to how they're shown in typescript-eslint.io/rules