### PR TITLE
Update the `name` of next config (`vite` -> `next`)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ export const configs = {
     },
   },
   next: {
-    name: "react-refresh/vite",
+    name: "react-refresh/next",
     plugins: { "react-refresh": plugin },
     rules: {
       "react-refresh/only-export-components": [


### PR DESCRIPTION
The `name` of next config is causing confusion. Seems to be a small typo during copy/paste :)