### PR TITLE
Remove experimental_ppr in next config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,6 @@ export const configs = {
         {
           allowExportNames: [
             // https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config
-            "experimental_ppr",
             "dynamic",
             "dynamicParams",
             "revalidate",


### PR DESCRIPTION
https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#version-history

> v16.0.0 | export const experimental_ppr = true removed. A codemod is available.
