### PR TITLE
Fix PascalCase class exported via `export { Name }` incorrectly treated as React component

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "eslint-plugin-react-refresh",
@@ -16,7 +17,7 @@
         "typescript": "~5.9",
       },
       "peerDependencies": {
-        "eslint": ">=9",
+        "eslint": "^9 || ^10",
       },
     },
   },

--- a/src/only-export-components.test.ts
+++ b/src/only-export-components.test.ts
@@ -287,6 +287,18 @@ export function Button(props: PropsWithChildren): ReactNode {
     code: "export const Link = () => {}; export const Styles = styled('div').attrs((props) => ({ className: 'form-control' }))``;",
     options: { extraHOCs: ["styled"] },
   },
+  {
+    name: "PascalCase class exported via export { Name } is not a component",
+    code: "class TimeObject { constructor() { this.years = {}; this.total = 0; } } const calcAmount = () => {}; export { calcAmount, TimeObject };",
+  },
+  {
+    name: "PascalCase class component exported via export { Name }",
+    code: "class MyComponent extends React.Component { render() { return null; } } export { MyComponent };",
+  },
+  {
+    name: "Variable with init exported via export { Name }",
+    code: "const Foo = () => {}; export { Foo };",
+  },
 ];
 
 const invalid: {
@@ -428,6 +440,11 @@ const invalid: {
     name: "Export default anonymous class component",
     code: "export default class { bar() { return <div>Hello</div>; } }",
     errorId: "anonymousExport",
+  },
+  {
+    name: "Class component and non-component via export { }",
+    code: "class MyComponent extends React.Component { render() { return null; } } const foo = () => {}; export { MyComponent, foo };",
+    errorId: "namedExport",
   },
 ];
 

--- a/src/only-export-components.test.ts
+++ b/src/only-export-components.test.ts
@@ -291,14 +291,6 @@ export function Button(props: PropsWithChildren): ReactNode {
     name: "PascalCase class exported via export { Name } is not a component",
     code: "class TimeObject { constructor() { this.years = {}; this.total = 0; } } const calcAmount = () => {}; export { calcAmount, TimeObject };",
   },
-  {
-    name: "PascalCase class component exported via export { Name }",
-    code: "class MyComponent extends React.Component { render() { return null; } } export { MyComponent };",
-  },
-  {
-    name: "Variable with init exported via export { Name }",
-    code: "const Foo = () => {}; export { Foo };",
-  },
 ];
 
 const invalid: {

--- a/src/only-export-components.ts
+++ b/src/only-export-components.ts
@@ -304,12 +304,44 @@ export const onlyExportComponents: TSESLint.RuleModule<
             hasExports = true;
             if (declaration) handleExportDeclaration(declaration);
             for (const specifier of node.specifiers) {
-              handleExportIdentifier(
+              const exportedNode =
                 specifier.exported.type === "Identifier"
-                  && specifier.exported.name === "default"
+                && specifier.exported.name === "default"
                   ? specifier.local
-                  : specifier.exported,
+                  : specifier.exported;
+
+              const scope = context.sourceCode.getScope(node);
+              const variable = scope.variables.find(
+                (v) => v.name === specifier.local.name,
               );
+              const def = variable?.defs[0];
+
+              if (def?.type === "ClassName") {
+                const classNode =
+                  def.node as unknown as TSESTree.ClassDeclaration;
+                if (
+                  reactComponentNameRE.test(exportedNode.name ?? "")
+                  && classNode.superClass !== null
+                  && classNode.body.body.some(
+                    (item) =>
+                      item.type === "MethodDefinition"
+                      && item.key.type === "Identifier"
+                      && item.key.name === "render",
+                  )
+                ) {
+                  hasReactExport = true;
+                } else {
+                  nonComponentExports.push(exportedNode);
+                }
+              } else if (
+                def?.type === "Variable"
+                && def.node.type === "VariableDeclarator"
+                && def.node.init !== null
+              ) {
+                handleExportIdentifier(exportedNode, def.node.init);
+              } else {
+                handleExportIdentifier(exportedNode);
+              }
             }
           } else if (node.type === "VariableDeclaration") {
             for (const variable of node.declarations) {

--- a/src/only-export-components.ts
+++ b/src/only-export-components.ts
@@ -304,44 +304,22 @@ export const onlyExportComponents: TSESLint.RuleModule<
             hasExports = true;
             if (declaration) handleExportDeclaration(declaration);
             for (const specifier of node.specifiers) {
-              const exportedNode =
-                specifier.exported.type === "Identifier"
-                && specifier.exported.name === "default"
-                  ? specifier.local
-                  : specifier.exported;
-
-              const scope = context.sourceCode.getScope(node);
-              const variable = scope.variables.find(
-                (v) => v.name === specifier.local.name,
-              );
-              const def = variable?.defs[0];
-
-              if (def?.type === "ClassName") {
-                const classNode =
-                  def.node as unknown as TSESTree.ClassDeclaration;
-                if (
-                  reactComponentNameRE.test(exportedNode.name ?? "")
-                  && classNode.superClass !== null
-                  && classNode.body.body.some(
-                    (item) =>
-                      item.type === "MethodDefinition"
-                      && item.key.type === "Identifier"
-                      && item.key.name === "render",
-                  )
-                ) {
-                  hasReactExport = true;
-                } else {
-                  nonComponentExports.push(exportedNode);
+              if (specifier.local.type === "Identifier") {
+                const scope = context.sourceCode.getScope(node);
+                const localName = specifier.local.name;
+                const def = scope.variables.find((v) => v.name === localName)
+                  ?.defs[0];
+                if (def?.type === "ClassName") {
+                  handleExportDeclaration(def.node);
+                  continue;
                 }
-              } else if (
-                def?.type === "Variable"
-                && def.node.type === "VariableDeclarator"
-                && def.node.init !== null
-              ) {
-                handleExportIdentifier(exportedNode, def.node.init);
-              } else {
-                handleExportIdentifier(exportedNode);
               }
+              handleExportIdentifier(
+                specifier.exported.type === "Identifier"
+                  && specifier.exported.name === "default"
+                  ? specifier.local
+                  : specifier.exported,
+              );
             }
           } else if (node.type === "VariableDeclaration") {
             for (const variable of node.declarations) {


### PR DESCRIPTION
When a PascalCase-named class is exported through `export { ClassName }`, resolve the local variable's declaration via scope analysis.

Fixes https://github.com/ArnaudBarre/eslint-plugin-react-refresh/issues/109