### PR TITLE
Fix SCREAMING_SNAKE_CASE constant exported via `export { Name }` incorrectly treated as React component

### DIFF
--- a/src/only-export-components.test.ts
+++ b/src/only-export-components.test.ts
@@ -291,6 +291,10 @@ export function Button(props: PropsWithChildren): ReactNode {
     name: "PascalCase class exported via export { Name } is not a component",
     code: "class TimeObject { constructor() { this.years = {}; this.total = 0; } } const calcAmount = () => {}; export { calcAmount, TimeObject };",
   },
+  {
+    name: "SCREAMING_SNAKE_CASE constant and class exported via export { Name }",
+    code: "const ENTITY_TYPE = 'Foo'; class SelectOption { constructor(label, value) { this.label = label; this.value = value; } } export { ENTITY_TYPE, SelectOption };",
+  },
 ];
 
 const invalid: {
@@ -436,6 +440,11 @@ const invalid: {
   {
     name: "Class component and non-component via export { }",
     code: "class MyComponent extends React.Component { render() { return null; } } const foo = () => {}; export { MyComponent, foo };",
+    errorId: "namedExport",
+  },
+  {
+    name: "Component and SCREAMING_SNAKE_CASE constant via export { }",
+    code: "const Foo = () => {}; const BAR = 1; export { Foo, BAR };",
     errorId: "namedExport",
   },
 ];

--- a/src/only-export-components.ts
+++ b/src/only-export-components.ts
@@ -313,6 +313,20 @@ export const onlyExportComponents: TSESLint.RuleModule<
                   handleExportDeclaration(def.node);
                   continue;
                 }
+                if (
+                  def?.type === "Variable"
+                  && def.node.type === "VariableDeclarator"
+                  && def.node.init !== null
+                ) {
+                  handleExportIdentifier(
+                    specifier.exported.type === "Identifier"
+                      && specifier.exported.name === "default"
+                      ? specifier.local
+                      : specifier.exported,
+                    def.node.init,
+                  );
+                  continue;
+                }
               }
               handleExportIdentifier(
                 specifier.exported.type === "Identifier"

--- a/src/only-export-components.ts
+++ b/src/only-export-components.ts
@@ -304,6 +304,11 @@ export const onlyExportComponents: TSESLint.RuleModule<
             hasExports = true;
             if (declaration) handleExportDeclaration(declaration);
             for (const specifier of node.specifiers) {
+              const identifier =
+                specifier.exported.type === "Identifier"
+                && specifier.exported.name === "default"
+                  ? specifier.local
+                  : specifier.exported;
               if (specifier.local.type === "Identifier") {
                 const scope = context.sourceCode.getScope(node);
                 const localName = specifier.local.name;
@@ -314,22 +319,11 @@ export const onlyExportComponents: TSESLint.RuleModule<
                   continue;
                 }
                 if (def?.type === "Variable" && def.node.init !== null) {
-                  handleExportIdentifier(
-                    specifier.exported.type === "Identifier"
-                      && specifier.exported.name === "default"
-                      ? specifier.local
-                      : specifier.exported,
-                    def.node.init,
-                  );
+                  handleExportIdentifier(identifier, def.node.init);
                   continue;
                 }
               }
-              handleExportIdentifier(
-                specifier.exported.type === "Identifier"
-                  && specifier.exported.name === "default"
-                  ? specifier.local
-                  : specifier.exported,
-              );
+              handleExportIdentifier(identifier);
             }
           } else if (node.type === "VariableDeclaration") {
             for (const variable of node.declarations) {

--- a/src/only-export-components.ts
+++ b/src/only-export-components.ts
@@ -313,11 +313,7 @@ export const onlyExportComponents: TSESLint.RuleModule<
                   handleExportDeclaration(def.node);
                   continue;
                 }
-                if (
-                  def?.type === "Variable"
-                  && def.node.type === "VariableDeclarator"
-                  && def.node.init !== null
-                ) {
+                if (def?.type === "Variable" && def.node.init !== null) {
                   handleExportIdentifier(
                     specifier.exported.type === "Identifier"
                       && specifier.exported.name === "default"


### PR DESCRIPTION
Fixes #113

Follow-up to #110, same code path: `export { Name }` specifiers referring to a local `const`/`let` variable were only checked by name (`reactComponentNameRE`), never by their actual initializer, unlike inline `export const X = ...`. Since the name regex allows underscores, SCREAMING_SNAKE_CASE constants (`ENTITY_TYPE`, `COLUMN_TEMPLATE`, ...) were misidentified as components when re-exported via a specifier list, causing false positives whenever the same file also exports something correctly classified as non-component (e.g. a plain class, per #110).

This mirrors the `ClassName` scope-resolution added in #110: for a specifier referring to a local variable declarator, resolve its initializer from scope and run it through the normal `handleExportIdentifier(identifier, init)` path instead of the name-only fallback.

Added regression tests for both the false positive (valid case) and to confirm real component/non-component mixes via `export { }` are still caught (invalid case).